### PR TITLE
Fix cannot show tail emoji in weex text

### DIFF
--- a/weex_core/Source/wson/wson_util.cpp
+++ b/weex_core/Source/wson/wson_util.cpp
@@ -141,9 +141,8 @@ namespace wson {
         for(int i=0; i<length;){
             u_int16_t c1 = utf16[i++];
             if(isHighSurrogate(c1)){
-                i++;
                 if(i < length){
-                    u_int16_t c2 = utf16[i];
+                    u_int16_t c2 = utf16[i++];
                     if (isLowSurrogate(c2)) {
                         u_int32_t codePoint =  toCodePoint(c1, c2);
                         count += utf16_char_convert_to_utf8_cstr(codePoint, src + count);
@@ -167,9 +166,8 @@ namespace wson {
         for(int i=0; i<length;){
             u_int16_t c1 = utf16[i++];
             if(isHighSurrogate(c1)){
-                i++;
                 if(i < length){
-                    u_int16_t c2 = utf16[i];
+                    u_int16_t c2 = utf16[i++];
                     if (isLowSurrogate(c2)) {
                         u_int32_t codePoint =  toCodePoint(c1, c2);
                         count += utf16_char_convert_to_utf8_cstr(codePoint, src + count);


### PR DESCRIPTION
Below text didn't show emoji in Android:

```
<text>{'\u7cbe\u9009\u603b\u611f\u89c9\ud83c\udf3b'}</text>
```

But, below text did (just append a normal char):

```
<text>{'\u7cbe\u9009\u603b\u611f\u89c9\ud83c\udf3b1'}</text>
```
